### PR TITLE
Fix missing llama-server binary causing "binary not found" error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,18 @@
 FROM docker.io/ollama/ollama:latest AS ollama
 
+# Drop GPU backends (each lives in its own subdir) in a separate stage so the
+# deleted bytes never end up in the final image's layers.
+FROM ollama AS ollama-cpu-only
+RUN rm -rf /usr/lib/ollama/cuda_v* /usr/lib/ollama/rocm_v* /usr/lib/ollama/vulkan /usr/lib/ollama/cuda_jetpack*
+
 FROM cgr.dev/chainguard/wolfi-base
 
 # ARG TARGETARCH
 
 RUN apk add --no-cache libstdc++
 
-COPY --from=ollama /usr/bin/ollama /usr/bin/ollama
-COPY --from=ollama /usr/lib/ollama/libggml-cpu-* /usr/lib/ollama/
-COPY --from=ollama /usr/lib/ollama/libggml-base.so /usr/lib/ollama/libggml-base.so
+COPY --from=ollama-cpu-only /usr/bin/ollama /usr/bin/ollama
+COPY --from=ollama-cpu-only /usr/lib/ollama /usr/lib/ollama
 
 # In arm64 ollama/ollama image, there is no avx libraries and seems they are not must-have (#2903, #3891)
 # COPY --from=ollama /usr/lib/ollama/runners/cpu_avx /usr/lib/ollama/runners/cpu_avx


### PR DESCRIPTION
## Summary
- Ollama 0.30+ moved inference out-of-process into a standalone `llama-server` binary plus supporting shared libraries (`libllama-server-impl.so`, `libllama.so`, `libmtmd.so`, etc.), all installed together under `/usr/lib/ollama/`. This Dockerfile only ever copied `libggml-cpu-*` and `libggml-base.so`, so `llama-server` was never present in the built image, breaking every model run with `llama-server binary not found`.
- Copy the whole `/usr/lib/ollama` directory instead of hand-picking files, and prune the GPU backend subdirs (`cuda_v*`, `rocm_v*`, `vulkan`, `cuda_jetpack*`) in a separate build stage so the deleted GPU bytes never end up in the final image's layers (a naive `rm -rf` in the final stage bloats the image to several GB due to layer history).

Fixes #12

## Test plan
- [x] Built the image locally and confirmed `/usr/lib/ollama` contains `llama-server` and all its dependent `.so` files
- [x] Ran the container, pulled `nomic-embed-text`, and ran `ollama run nomic-embed-text helloworld` — got a real embedding back (previously failed with the binary-not-found error)
- [x] Confirmed final image size stays close to the original ~85MB (measured ~105MB) rather than ballooning with GPU backend libraries

🤖 Generated with [Claude Code](https://claude.com/claude-code)